### PR TITLE
Compile got deprecated

### DIFF
--- a/gmail/quickstart/build.gradle
+++ b/gmail/quickstart/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
 }


### PR DESCRIPTION
The compile dependency configuration got deprecated from gradle 7+ .