### PR TITLE
Update build.gradle

### DIFF
--- a/adminSDK/alertcenter/quickstart/build.gradle
+++ b/adminSDK/alertcenter/quickstart/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'application'
 apply plugin: 'idea'
 
 mainClassName = 'AdminSDKAlertCenterQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.auth:google-auth-library-oauth2-http:0.11.0'
-    compile 'com.google.apis:google-api-services-alertcenter:v1beta1-rev20190221-1.28.0'
+    implementation 'com.google.api-client:google-api-client:1.20.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:0.11.0'
+    implementation 'com.google.apis:google-api-services-alertcenter:v1beta1-rev20190221-1.28.0'
 }

--- a/adminSDK/directory/quickstart/build.gradle
+++ b/adminSDK/directory/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKDirectoryQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
-    compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
+    implementation 'com.google.api-client:google-api-client:1.20.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
+    implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
 }

--- a/adminSDK/reports/quickstart/build.gradle
+++ b/adminSDK/reports/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKReportsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
-    compile 'com.google.apis:google-api-services-admin-reports:reports_v1-rev46-1.20.0'
+    implementation 'com.google.api-client:google-api-client:1.20.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
+    implementation 'com.google.apis:google-api-services-admin-reports:reports_v1-rev46-1.20.0'
 }

--- a/adminSDK/reseller/quickstart/build.gradle
+++ b/adminSDK/reseller/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKResellerQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-reseller:v1-rev70-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-reseller:v1-rev70-1.23.0'
 }

--- a/appsScript/quickstart/build.gradle
+++ b/appsScript/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AppsScriptQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-script:v1-rev175-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-script:v1-rev175-1.23.0'
 }

--- a/calendar/quickstart/build.gradle
+++ b/calendar/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'CalendarQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-calendar:v3-rev305-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-calendar:v3-rev305-1.23.0'
 }

--- a/classroom/quickstart/build.gradle
+++ b/classroom/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'ClassroomQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-classroom:v1-rev135-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-classroom:v1-rev135-1.23.0'
 }

--- a/docs/outputJSON/build.gradle
+++ b/docs/outputJSON/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'OutputJSON'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-docs:v1-rev20190128-1.28.0'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-docs:v1-rev20190128-1.28.0'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
 }

--- a/docs/quickstart/build.gradle
+++ b/docs/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DocsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.1'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.1'
-    compile 'com.google.apis:google-api-services-docs:v1-rev20190827-1.30.1'
+    implementation 'com.google.api-client:google-api-client:1.30.1'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.30.1'
+    implementation 'com.google.apis:google-api-services-docs:v1-rev20190827-1.30.1'
 }

--- a/drive/activity-v2/quickstart/build.gradle
+++ b/drive/activity-v2/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DriveActivityQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.27.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.27.0'
-    compile 'com.google.apis:google-api-services-driveactivity:v2-rev20190423-1.27.0'
+    implementation 'com.google.api-client:google-api-client:1.27.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.27.0'
+    implementation 'com.google.apis:google-api-services-driveactivity:v2-rev20190423-1.27.0'
 }

--- a/drive/activity/quickstart/build.gradle
+++ b/drive/activity/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DriveActivityQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-appsactivity:v1-rev136-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-appsactivity:v1-rev136-1.23.0'
 }

--- a/drive/quickstart/build.gradle
+++ b/drive/quickstart/build.gradle
@@ -5,12 +5,13 @@ mainClassName = 'DriveQuickstart'
 sourceCompatibility = 11
 targetCompatibility = 11
 version = '1.0'
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev110-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev110-1.23.0'
 }

--- a/gmail/quickstart/build.gradle
+++ b/gmail/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'GmailQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
 }

--- a/people/quickstart/build.gradle
+++ b/people/quickstart/build.gradle
@@ -2,9 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'PeopleQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-people:v1-rev277-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-people:v1-rev277-1.23.0'
 }

--- a/sheets/quickstart/build.gradle
+++ b/sheets/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'SheetsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.4'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.6'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
+    implementation 'com.google.api-client:google-api-client:1.30.4'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.30.6'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
 }

--- a/sheets/snippets/build.gradle
+++ b/sheets/snippets/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'java'
 
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.22.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev30-1.22.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.api-client:google-api-client:1.22.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev30-1.22.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 test {

--- a/slides/quickstart/build.gradle
+++ b/slides/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'SlidesQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
 }

--- a/slides/snippets/build.gradle
+++ b/slides/snippets/build.gradle
@@ -1,18 +1,17 @@
 apply plugin: 'java'
 
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.22.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev34-1.22.0'
-    compile 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.api-client:google-api-client:1.22.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev34-1.22.0'
+    implementation 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
+    testImplementation 'junit:junit:4.12'
 
-    compile fileTree(dir: 'lib', include: ['*.jar'])
+    implementation fileTree(dir: 'lib', include: ['*.jar'])
 }
 
 test {

--- a/tasks/quickstart/build.gradle
+++ b/tasks/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'TasksQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-tasks:v1-rev49-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-tasks:v1-rev49-1.23.0'
 }

--- a/vault/quickstart/build.gradle
+++ b/vault/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'Quickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
 }

--- a/vault/vault-hold-migration-api/build.gradle
+++ b/vault/vault-hold-migration-api/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'application'
 apply plugin: 'idea'
 
 mainClassName = 'com.google.vault.chatmigration.QuickStart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,11 +12,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
-    compile group: 'org.apache.commons', name: 'commons-csv', version: '1.1'
-    compile "com.github.rholder:guava-retrying:2.0.0"
-    compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
+    implementation 'com.google.api-client:google-api-client:1.23.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+    implementation 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
+    implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.1'
+    implementation "com.github.rholder:guava-retrying:2.0.0"
+    implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.4'
 }


### PR DESCRIPTION
- The compile dependency configuration got deprecated from gradle 7+
- 'jcenter' is deprecated
- Updated Java Quickstarts to Java 11