### PR TITLE
Update in build.gradle, pom.xml and java files.

### DIFF
--- a/adminSDK/alertcenter/quickstart/build.gradle
+++ b/adminSDK/alertcenter/quickstart/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'application'
 apply plugin: 'idea'
 
 mainClassName = 'AdminSDKAlertCenterQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.auth:google-auth-library-oauth2-http:0.11.0'
-    compile 'com.google.apis:google-api-services-alertcenter:v1beta1-rev20190221-1.28.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
+    implementation 'com.google.apis:google-api-services-alertcenter:v1beta1-rev20211012-1.32.1'
 }

--- a/adminSDK/alertcenter/quickstart/src/main/java/AdminSDKAlertCenterQuickstart.java
+++ b/adminSDK/alertcenter/quickstart/src/main/java/AdminSDKAlertCenterQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.alertcenter.v1beta1.AlertCenter;
 import com.google.api.services.alertcenter.v1beta1.AlertCenterScopes;
 import com.google.api.services.alertcenter.v1beta1.model.Alert;
@@ -37,7 +37,7 @@ import java.util.List;
 public class AdminSDKAlertCenterQuickstart {
 
   private static final String APPLICATION_NAME = "Google Admin SDK Alert Center API Java Quickstart";
-  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
   /**
    * Global instance of the scopes required by this quickstart.

--- a/adminSDK/directory/quickstart/build.gradle
+++ b/adminSDK/directory/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKDirectoryQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
-    compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev118-1.25.0'
 }

--- a/adminSDK/directory/quickstart/src/main/java/AdminSDKDirectoryQuickstart.java
+++ b/adminSDK/directory/quickstart/src/main/java/AdminSDKDirectoryQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.admin.directory.Directory;
 import com.google.api.services.admin.directory.DirectoryScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class AdminSDKDirectoryQuickstart {
     private static final String APPLICATION_NAME = "Google Admin SDK Directory API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/adminSDK/reports/quickstart/build.gradle
+++ b/adminSDK/reports/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKReportsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.20.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.20.0'
-    compile 'com.google.apis:google-api-services-admin-reports:reports_v1-rev46-1.20.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-admin-reports:reports_v1-rev89-1.25.0'
 }

--- a/adminSDK/reports/quickstart/src/main/java/AdminSDKReportsQuickstart.java
+++ b/adminSDK/reports/quickstart/src/main/java/AdminSDKReportsQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.admin.reports.Reports;
 import com.google.api.services.admin.reports.ReportsScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class AdminSDKReportsQuickstart {
     private static final String APPLICATION_NAME = "Google Admin SDK Reports API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/adminSDK/reseller/quickstart/build.gradle
+++ b/adminSDK/reseller/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AdminSDKResellerQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-reseller:v1-rev70-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-reseller:v1-rev20211106-1.32.1'
 }

--- a/adminSDK/reseller/quickstart/src/main/java/AdminSDKResellerQuickstart.java
+++ b/adminSDK/reseller/quickstart/src/main/java/AdminSDKResellerQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.reseller.Reseller;
 import com.google.api.services.reseller.ResellerScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class AdminSDKResellerQuickstart {
     private static final String APPLICATION_NAME = "Google Admin SDK Reseller API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/appsScript/quickstart/build.gradle
+++ b/appsScript/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'AppsScriptQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-script:v1-rev175-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-script:v1-rev20210703-1.32.1'
 }

--- a/appsScript/quickstart/src/main/java/AppsScriptQuickstart.java
+++ b/appsScript/quickstart/src/main/java/AppsScriptQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.script.Script;
 import com.google.api.services.script.model.Content;
@@ -40,7 +40,7 @@ import java.util.List;
 
 public class AppsScriptQuickstart {
     private static final String APPLICATION_NAME = "Apps Script API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/calendar/quickstart/build.gradle
+++ b/calendar/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'CalendarQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-calendar:v3-rev305-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-calendar:v3-rev20211026-1.32.1'
 }

--- a/calendar/quickstart/src/main/java/CalendarQuickstart.java
+++ b/calendar/quickstart/src/main/java/CalendarQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.DateTime;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.calendar.Calendar;
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class CalendarQuickstart {
     private static final String APPLICATION_NAME = "Google Calendar API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/calendar/sync/pom.xml
+++ b/calendar/sync/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -21,6 +20,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-calendar</artifactId>
-      <version>v3-rev81-1.18.0-rc</version>
+      <version>v3-rev20211026-1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.18.0-rc</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
@@ -81,8 +81,8 @@
   </dependencies>
 
   <properties>
-    <project.http.version>1.18.0-rc</project.http.version>
-    <project.oauth.version>1.18.0-rc</project.oauth.version>
+    <project.http.version>1.40.1</project.http.version>
+    <project.oauth.version>1.32.1</project.oauth.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/classroom/quickstart/build.gradle
+++ b/classroom/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'ClassroomQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-classroom:v1-rev135-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-classroom:v1-rev20211029-1.32.1'
 }

--- a/classroom/quickstart/src/main/java/ClassroomQuickstart.java
+++ b/classroom/quickstart/src/main/java/ClassroomQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.classroom.ClassroomScopes;
 import com.google.api.services.classroom.model.*;
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class ClassroomQuickstart {
     private static final String APPLICATION_NAME = "Google Classroom API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/docs/outputJSON/build.gradle
+++ b/docs/outputJSON/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'OutputJSON'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,8 +11,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-docs:v1-rev20190128-1.28.0'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-docs:v1-rev20210707-1.32.1'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }

--- a/docs/outputJSON/src/main/java/OutputJSON.java
+++ b/docs/outputJSON/src/main/java/OutputJSON.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.docs.v1.Docs;
 import com.google.api.services.docs.v1.DocsScopes;
@@ -40,7 +40,7 @@ import java.util.List;
  */
 public class OutputJSON {
     private static final String APPLICATION_NAME = "Google Docs API Document Contents";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
     private static final String DOCUMENT_ID = "YOUR_DOCUMENT_ID";
 

--- a/docs/quickstart/build.gradle
+++ b/docs/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DocsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.1'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.1'
-    compile 'com.google.apis:google-api-services-docs:v1-rev20190827-1.30.1'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-docs:v1-rev20210707-1.32.1'
 }

--- a/docs/quickstart/src/main/java/DocsQuickstart.java
+++ b/docs/quickstart/src/main/java/DocsQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.docs.v1.Docs;
 import com.google.api.services.docs.v1.DocsScopes;
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class DocsQuickstart {
     private static final String APPLICATION_NAME = "Google Docs API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
     private static final String DOCUMENT_ID = "195j9eDD3ccgjQRttHhJPymLJUCOUjs-jmwTrekvdjFE";
 

--- a/drive/activity-v2/quickstart/build.gradle
+++ b/drive/activity-v2/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DriveActivityQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.27.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.27.0'
-    compile 'com.google.apis:google-api-services-driveactivity:v2-rev20190423-1.27.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-driveactivity:v2-rev20210319-1.32.1'
 }

--- a/drive/activity-v2/quickstart/src/main/java/DriveActivityQuickstart.java
+++ b/drive/activity-v2/quickstart/src/main/java/DriveActivityQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.driveactivity.v2.DriveActivityScopes;
 import com.google.api.services.driveactivity.v2.model.*;
@@ -46,7 +46,7 @@ public class DriveActivityQuickstart {
     private static FileDataStoreFactory DATA_STORE_FACTORY;
 
     /** Global instance of the JSON factory. */
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
     /** Global instance of the HTTP transport. */
     private static HttpTransport HTTP_TRANSPORT;

--- a/drive/activity/quickstart/build.gradle
+++ b/drive/activity/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'DriveActivityQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-appsactivity:v1-rev136-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-appsactivity:v1-rev20200128-1.30.10'
 }

--- a/drive/activity/quickstart/src/main/java/DriveActivityQuickstart.java
+++ b/drive/activity/quickstart/src/main/java/DriveActivityQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 
@@ -49,7 +49,7 @@ public class DriveActivityQuickstart {
 
     /** Global instance of the JSON factory. */
     private static final JsonFactory JSON_FACTORY =
-        JacksonFactory.getDefaultInstance();
+        GsonFactory.getDefaultInstance();
 
     /** Global instance of the HTTP transport. */
     private static HttpTransport HTTP_TRANSPORT;

--- a/drive/quickstart/build.gradle
+++ b/drive/quickstart/build.gradle
@@ -5,7 +5,6 @@ mainClassName = 'DriveQuickstart'
 sourceCompatibility = 11
 targetCompatibility = 11
 version = '1.0'
-
 repositories {
     mavenCentral()
 }

--- a/drive/quickstart/build.gradle
+++ b/drive/quickstart/build.gradle
@@ -5,12 +5,13 @@ mainClassName = 'DriveQuickstart'
 sourceCompatibility = 11
 targetCompatibility = 11
 version = '1.0'
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev110-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev20211107-1.32.1'
 }

--- a/drive/quickstart/src/main/java/DriveQuickstart.java
+++ b/drive/quickstart/src/main/java/DriveQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class DriveQuickstart {
     private static final String APPLICATION_NAME = "Google Drive API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/gmail/quickstart/build.gradle
+++ b/gmail/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'GmailQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-gmail:v1-rev20211108-1.32.1'
 }

--- a/gmail/quickstart/src/main/java/GmailQuickstart.java
+++ b/gmail/quickstart/src/main/java/GmailQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.GmailScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class GmailQuickstart {
     private static final String APPLICATION_NAME = "Gmail API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/people/quickstart/build.gradle
+++ b/people/quickstart/build.gradle
@@ -2,9 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'PeopleQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-people:v1-rev277-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-people:v1-rev20210903-1.32.1'
 }

--- a/people/quickstart/src/main/java/PeopleQuickstart.java
+++ b/people/quickstart/src/main/java/PeopleQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.people.v1.PeopleService;
 import com.google.api.services.people.v1.PeopleServiceScopes;
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class PeopleQuickstart {
     private static final String APPLICATION_NAME = "Google People API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/sheets/quickstart/build.gradle
+++ b/sheets/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'SheetsQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.4'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.6'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev20210629-1.32.1'
 }

--- a/sheets/quickstart/src/main/java/SheetsQuickstart.java
+++ b/sheets/quickstart/src/main/java/SheetsQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.SheetsScopes;
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class SheetsQuickstart {
     private static final String APPLICATION_NAME = "Google Sheets API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/sheets/snippets/build.gradle
+++ b/sheets/snippets/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'java'
 
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.22.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev30-1.22.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev20211107-1.32.1'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev20210629-1.32.1'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 test {

--- a/sheets/snippets/src/test/java/BaseTest.java
+++ b/sheets/snippets/src/test/java/BaseTest.java
@@ -1,7 +1,8 @@
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.sheets.v4.Sheets;
@@ -59,34 +60,34 @@ public class BaseTest {
     });
   }
 
-  public GoogleCredential getCredential() throws IOException {
-    return GoogleCredential.getApplicationDefault()
-        .createScoped(Arrays.asList(DriveScopes.DRIVE));
+  public GoogleCredentials getCredential() throws IOException {
+    return GoogleCredentials.getApplicationDefault()
+            .createScoped(Arrays.asList(DriveScopes.DRIVE));
   }
 
-  public Sheets buildService(GoogleCredential credential) throws IOException,
-      GeneralSecurityException {
+  public Sheets buildService(GoogleCredentials credential) throws IOException,
+          GeneralSecurityException {
     return new Sheets.Builder(
-        GoogleNetHttpTransport.newTrustedTransport(),
-        JacksonFactory.getDefaultInstance(),
-        credential)
-        .setApplicationName("Sheets API Snippets")
-        .build();
+            GoogleNetHttpTransport.newTrustedTransport(),
+            GsonFactory.getDefaultInstance(),
+            new HttpCredentialsAdapter(credential))
+            .setApplicationName("Sheets API Snippets")
+            .build();
   }
 
-  public Drive buildDriveService(GoogleCredential credential)
-      throws IOException, GeneralSecurityException {
+  public Drive buildDriveService(GoogleCredentials credential)
+          throws IOException, GeneralSecurityException {
     return new Drive.Builder(
-        GoogleNetHttpTransport.newTrustedTransport(),
-        JacksonFactory.getDefaultInstance(),
-        credential)
-        .setApplicationName("Sheets API Snippets")
-        .build();
+            GoogleNetHttpTransport.newTrustedTransport(),
+            GsonFactory.getDefaultInstance(),
+            new HttpCredentialsAdapter(credential))
+            .setApplicationName("Sheets API Snippets")
+            .build();
   }
 
   @Before
   public void setup() throws IOException, GeneralSecurityException {
-    GoogleCredential credential = getCredential();
+    GoogleCredentials credential = getCredential();
     this.service = buildService(credential);
     this.driveService = buildDriveService(credential);
     this.filesToDelete.clear();
@@ -109,47 +110,47 @@ public class BaseTest {
 
   protected String createTestSpreadsheet() throws IOException {
     Spreadsheet spreadsheet = new Spreadsheet()
-        .setProperties(new SpreadsheetProperties()
-            .setTitle("Test Spreadsheet"));
+            .setProperties(new SpreadsheetProperties()
+                    .setTitle("Test Spreadsheet"));
     spreadsheet = service.spreadsheets().create(spreadsheet)
-        .setFields("spreadsheetId")
-        .execute();
+            .setFields("spreadsheetId")
+            .execute();
     return spreadsheet.getSpreadsheetId();
   }
 
   protected void populateValuesWithStrings(String spreadsheetId) throws IOException {
     List<Request> requests = new ArrayList<>();
     requests.add(new Request().setRepeatCell(new RepeatCellRequest()
-        .setRange(new GridRange()
-            .setSheetId(0)
-            .setStartRowIndex(0)
-            .setEndRowIndex(10)
-            .setStartColumnIndex(0)
-            .setEndColumnIndex(10))
-        .setCell(new CellData()
-            .setUserEnteredValue(new ExtendedValue()
-                .setStringValue("Hello")))
-        .setFields("userEnteredValue")));
+            .setRange(new GridRange()
+                    .setSheetId(0)
+                    .setStartRowIndex(0)
+                    .setEndRowIndex(10)
+                    .setStartColumnIndex(0)
+                    .setEndColumnIndex(10))
+            .setCell(new CellData()
+                    .setUserEnteredValue(new ExtendedValue()
+                            .setStringValue("Hello")))
+            .setFields("userEnteredValue")));
     BatchUpdateSpreadsheetRequest body = new BatchUpdateSpreadsheetRequest()
-        .setRequests(requests);
+            .setRequests(requests);
     service.spreadsheets().batchUpdate(spreadsheetId, body).execute();
   }
 
   protected void populateValuesWithNumbers(String spreadsheetId) throws IOException {
     List<Request> requests = new ArrayList<>();
     requests.add(new Request().setRepeatCell(new RepeatCellRequest()
-        .setRange(new GridRange()
-            .setSheetId(0)
-            .setStartRowIndex(0)
-            .setEndRowIndex(10)
-            .setStartColumnIndex(0)
-            .setEndColumnIndex(10))
-        .setCell(new CellData()
-            .setUserEnteredValue(new ExtendedValue()
-                .setNumberValue(1337D)))
-        .setFields("userEnteredValue")));
+            .setRange(new GridRange()
+                    .setSheetId(0)
+                    .setStartRowIndex(0)
+                    .setEndRowIndex(10)
+                    .setStartColumnIndex(0)
+                    .setEndColumnIndex(10))
+            .setCell(new CellData()
+                    .setUserEnteredValue(new ExtendedValue()
+                            .setNumberValue(1337D)))
+            .setFields("userEnteredValue")));
     BatchUpdateSpreadsheetRequest body = new BatchUpdateSpreadsheetRequest()
-        .setRequests(requests);
+            .setRequests(requests);
     service.spreadsheets().batchUpdate(spreadsheetId, body).execute();
   }
 }

--- a/slides/quickstart/build.gradle
+++ b/slides/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'SlidesQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-slides:v1-rev20210820-1.32.1'
 }

--- a/slides/quickstart/src/main/java/SlidesQuickstart.java
+++ b/slides/quickstart/src/main/java/SlidesQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.slides.v1.Slides;
 import com.google.api.services.slides.v1.SlidesScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class SlidesQuickstart {
     private static final String APPLICATION_NAME = "Google Slides API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**

--- a/slides/snippets/build.gradle
+++ b/slides/snippets/build.gradle
@@ -1,18 +1,17 @@
 apply plugin: 'java'
 
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.22.0'
-    compile 'com.google.apis:google-api-services-drive:v3-rev45-1.22.0'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev34-1.22.0'
-    compile 'com.google.apis:google-api-services-slides:v1-rev294-1.23.0'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
+    implementation 'com.google.apis:google-api-services-drive:v3-rev20211107-1.32.1'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev20210629-1.32.1'
+    implementation 'com.google.apis:google-api-services-slides:v1-rev20210820-1.32.1'
+    testImplementation 'junit:junit:4.13.2'
 
-    compile fileTree(dir: 'lib', include: ['*.jar'])
+    implementation fileTree(dir: 'lib', include: ['*.jar'])
 }
 
 test {

--- a/slides/snippets/src/main/java/Snippets.java
+++ b/slides/snippets/src/main/java/Snippets.java
@@ -1,4 +1,4 @@
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
 import com.google.api.services.sheets.v4.Sheets;
@@ -119,7 +119,7 @@ public class Snippets {
 
     public BatchUpdatePresentationResponse createImage(String presentationId,
                                                        String slideId,
-                                                       GoogleCredential credential)
+                                                       GoogleCredentials credential)
             throws IOException {
         Slides slidesService = this.service;
         // [START slides_create_image]

--- a/slides/snippets/src/test/java/BaseTest.java
+++ b/slides/snippets/src/test/java/BaseTest.java
@@ -1,7 +1,8 @@
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.sheets.v4.Sheets;
@@ -25,7 +26,7 @@ public class BaseTest {
         enableLogging();
     }
 
-    protected GoogleCredential credential;
+    protected GoogleCredentials credential;
     protected Slides service;
     protected Drive driveService;
     protected Sheets sheetsService;
@@ -55,37 +56,37 @@ public class BaseTest {
         });
     }
 
-    public GoogleCredential getCredential() throws IOException {
-        return GoogleCredential.getApplicationDefault()
+    public GoogleCredentials getCredential() throws IOException {
+        return GoogleCredentials.getApplicationDefault()
                 .createScoped(Arrays.asList(DriveScopes.DRIVE));
     }
 
-    public Slides buildService(GoogleCredential credential)
+    public Slides buildService(GoogleCredentials credential)
             throws IOException, GeneralSecurityException {
         return new Slides.Builder(
                 GoogleNetHttpTransport.newTrustedTransport(),
-                JacksonFactory.getDefaultInstance(),
-                credential)
+                GsonFactory.getDefaultInstance(),
+                new HttpCredentialsAdapter(credential))
                 .setApplicationName("Slides API Snippets")
                 .build();
     }
 
-    public Drive buildDriveService(GoogleCredential credential)
+    public Drive buildDriveService(GoogleCredentials credential)
             throws IOException, GeneralSecurityException {
         return new Drive.Builder(
                 GoogleNetHttpTransport.newTrustedTransport(),
-                JacksonFactory.getDefaultInstance(),
-                credential)
+                GsonFactory.getDefaultInstance(),
+                new HttpCredentialsAdapter(credential))
                 .setApplicationName("Slides API Snippets")
                 .build();
     }
 
-    public Sheets buildSheetsService(GoogleCredential credential)
+    public Sheets buildSheetsService(GoogleCredentials credential)
             throws IOException, GeneralSecurityException {
         return new Sheets.Builder(
                 GoogleNetHttpTransport.newTrustedTransport(),
-                JacksonFactory.getDefaultInstance(),
-                credential)
+                GsonFactory.getDefaultInstance(),
+                new HttpCredentialsAdapter(credential))
                 .setApplicationName("Slides API Snippets")
                 .build();
     }

--- a/tasks/quickstart/build.gradle
+++ b/tasks/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'TasksQuickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-tasks:v1-rev49-1.23.0'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-tasks:v1-rev20210709-1.32.1'
 }

--- a/tasks/quickstart/src/main/java/TasksQuickstart.java
+++ b/tasks/quickstart/src/main/java/TasksQuickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.tasks.Tasks;
 import com.google.api.services.tasks.TasksScopes;
@@ -38,7 +38,7 @@ import java.util.List;
 
 public class TasksQuickstart {
     private static final String APPLICATION_NAME = "Google Tasks API Java Quickstart";
-    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
 
     /**
@@ -81,7 +81,7 @@ public class TasksQuickstart {
 
         // Print the first 10 task lists.
         TaskLists result = service.tasklists().list()
-                .setMaxResults(10L)
+                .setMaxResults(10)
                 .execute();
         List<TaskList> taskLists = result.getItems();
         if (taskLists == null || taskLists.isEmpty()) {

--- a/vault/quickstart/build.gradle
+++ b/vault/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'Quickstart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-vault:v1-rev20211101-1.32.1'
 }

--- a/vault/quickstart/src/main/java/Quickstart.java
+++ b/vault/quickstart/src/main/java/Quickstart.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.vault.v1.VaultScopes;
@@ -41,13 +41,14 @@ public class Quickstart {
 
     /** Directory to store authorization tokens for this application. */
     private static final java.io.File DATA_STORE_DIR = new java.io.File("tokens");
+    private static final String CREDENTIALS_FILE_PATH = "/credentials.json";
 
     /** Global instance of the {@link FileDataStoreFactory}. */
     private static FileDataStoreFactory DATA_STORE_FACTORY;
 
     /** Global instance of the JSON factory. */
     private static final JsonFactory JSON_FACTORY =
-        JacksonFactory.getDefaultInstance();
+        GsonFactory.getDefaultInstance();
 
     /** Global instance of the HTTP transport. */
     private static HttpTransport HTTP_TRANSPORT;

--- a/vault/vault-hold-migration-api/build.gradle
+++ b/vault/vault-hold-migration-api/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'application'
 apply plugin: 'idea'
 
 mainClassName = 'com.google.vault.chatmigration.QuickStart'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 version = '1.0'
 
 repositories {
@@ -12,11 +12,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-vault:v1-rev8-1.23.0' 
-    compile group: 'org.apache.commons', name: 'commons-csv', version: '1.1'
-    compile "com.github.rholder:guava-retrying:2.0.0"
-    compile 'com.google.apis:google-api-services-admin-directory:directory_v1-rev53-1.20.0'
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
+    implementation 'com.google.api-client:google-api-client:1.32.2'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.32.1'
+    implementation 'com.google.apis:google-api-services-vault:v1-rev20211101-1.32.1'
+    implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.9.0'
+    implementation 'com.github.rholder:guava-retrying:2.0.0'
+    implementation 'com.google.apis:google-api-services-admin-directory:directory_v1-rev118-1.25.0'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.5.0'
 }

--- a/vault/vault-hold-migration-api/src/main/java/com/google/vault/chatmigration/MigrationHelper.java
+++ b/vault/vault-hold-migration-api/src/main/java/com/google/vault/chatmigration/MigrationHelper.java
@@ -8,7 +8,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.admin.directory.Directory;
 import com.google.api.services.admin.directory.DirectoryScopes;
@@ -60,7 +60,7 @@ public class MigrationHelper {
   private static FileDataStoreFactory DATA_STORE_FACTORY;
 
   /** Global instance of the JSON factory. */
-  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
   /** Global instance of the HTTP transport. */
   private static HttpTransport HTTP_TRANSPORT;


### PR DESCRIPTION
- The compile dependency configuration got deprecated from gradle 7+
- 'jcenter' is deprecated
- 'GoogleCredential' class of google-api-client got deprecated.
- 'setMaxResults' method parameter changed from Long to Integer in TasksQuickstart.java
- Updated Java Quickstarts to Java 11